### PR TITLE
Reduce Mixin Conflicts within CreeperEntity

### DIFF
--- a/src/main/java/cat/tophat/creepycreepers/common/entities/CreepyCreeperEntity.java
+++ b/src/main/java/cat/tophat/creepycreepers/common/entities/CreepyCreeperEntity.java
@@ -20,7 +20,7 @@ public class CreepyCreeperEntity extends CreeperEntity {
 	/**
 	 * The sound to be played when ignited.
 	 */
-	private final Lazy<SoundEvent> ignitedSound;
+	protected final Lazy<SoundEvent> ignitedSound;
 	
 	/**
 	 * Constructor for the creeper.
@@ -49,7 +49,7 @@ public class CreepyCreeperEntity extends CreeperEntity {
 	 * This method is extending an implementation on a
 	 * mixin so no override is necessary.
 	 */
-	public void onIgnited() {
+	public void onIgnited(float volume, float pitch) {
 		this.playSound(this.ignitedSound.get(), 1.0F, 1.0F);
 	}
 }

--- a/src/main/java/cat/tophat/creepycreepers/common/entities/ICreeper.java
+++ b/src/main/java/cat/tophat/creepycreepers/common/entities/ICreeper.java
@@ -10,6 +10,9 @@ public interface ICreeper {
 
 	/**
 	 * Called when the creeper has been first ignited.
+	 * 
+	 * @param volume The original sound volume.
+	 * @param pitch The original sound pitch.
 	 */
 	void onIgnited(float volume, float pitch);
 }

--- a/src/main/java/cat/tophat/creepycreepers/common/entities/ICreeper.java
+++ b/src/main/java/cat/tophat/creepycreepers/common/entities/ICreeper.java
@@ -11,5 +11,5 @@ public interface ICreeper {
 	/**
 	 * Called when the creeper has been first ignited.
 	 */
-	void onIgnited();
+	void onIgnited(float volume, float pitch);
 }

--- a/src/main/java/cat/tophat/creepycreepers/mixin/CreeperEntityMixin.java
+++ b/src/main/java/cat/tophat/creepycreepers/mixin/CreeperEntityMixin.java
@@ -1,13 +1,14 @@
 package cat.tophat.creepycreepers.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 import cat.tophat.creepycreepers.common.entities.ICreeper;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.monster.CreeperEntity;
 import net.minecraft.entity.monster.MonsterEntity;
+import net.minecraft.util.SoundEvent;
 import net.minecraft.util.SoundEvents;
 import net.minecraft.world.World;
 
@@ -18,50 +19,21 @@ import net.minecraft.world.World;
  */
 @Mixin(CreeperEntity.class)
 public abstract class CreeperEntityMixin extends MonsterEntity implements ICreeper {
-
-	@Shadow private int lastActiveTime;
-	@Shadow private int timeSinceIgnited;
-	@Shadow private int fuseTime;
-	@Shadow public abstract boolean hasIgnited();
-	@Shadow public abstract void setCreeperState(int state);
-	@Shadow public abstract int getCreeperState();
-	@Shadow protected abstract void explode();
 	
 	private CreeperEntityMixin(EntityType<? extends MonsterEntity> type, World worldIn) {
 		super(type, worldIn);
 	}
 
 	/**
-	 * Creeper tick
+	 * Used to play the ignition sound within the creeper tick method.
 	 */
-	@Overwrite
-	public void tick() {
-		if (this.isAlive()) {
-			this.lastActiveTime = this.timeSinceIgnited;
-			if (this.hasIgnited()) {
-				this.setCreeperState(1);
-			}
-
-			int i = this.getCreeperState();
-			if (i > 0 && this.timeSinceIgnited == 0) {
-				this.onIgnited();
-			}
-
-			this.timeSinceIgnited += i;
-			if (this.timeSinceIgnited < 0) {
-				this.timeSinceIgnited = 0;
-			}
-
-			if (this.timeSinceIgnited >= this.fuseTime) {
-				this.timeSinceIgnited = this.fuseTime;
-				this.explode();
-			}
-		}
-		super.tick();
+	@Redirect(method = "tick()V", at = @At(value = "INVOKE", target = "playSound(Lnet/minecraft/util/SoundEvent;FF)V"))
+	public void playIgnitionSound(CreeperEntity entity, SoundEvent sound, float volume, float pitch) {
+		this.onIgnited(volume, pitch);
 	}
 	
 	@Override
-	public void onIgnited() {
-		this.playSound(SoundEvents.ENTITY_CREEPER_PRIMED, 1.0F, 0.5F);
+	public void onIgnited(float volume, float pitch) {
+		this.playSound(SoundEvents.ENTITY_CREEPER_PRIMED, volume, pitch);
 	}
 }


### PR DESCRIPTION
Adjusts from using overwrite to redirect as there is only one call to `playSound` within the tick event. Updates `ICreeper` interface accordingly to grab the original volume and pitch of the sound. Also makes the lazy protected for sound accessibility if `onIgnited` is overridden.